### PR TITLE
Document shortcut to install peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ This package provides GitBook's .eslintrc as an extensible shared config. It is 
 ### Installation
 
 ```
-$ npm install eslint-config-gitbook --save-dev
+npm install eslint-config-gitbook --save-dev
+```
+
+With npm 5+, you can now install the package along with its peer dependencies easily:
+
+```
+npx install-peerdeps --dev eslint-config-gitbook
 ```
 
 ### Usage


### PR DESCRIPTION
Just saw that from airbnb's config README: https://www.npmjs.com/package/eslint-config-airbnb#eslint-config-airbnb-1

I gave it a try and it works like a charm 👌 